### PR TITLE
Drop HTTPoison dependency and allow to specify request type

### DIFF
--- a/lib/httpdigest.ex
+++ b/lib/httpdigest.ex
@@ -2,7 +2,7 @@ defmodule Httpdigest do
   def get_header(headers, key) do
     headers
     |> Enum.filter(fn({k, _}) -> k == key end)
-    |> hd
+    |> hd()
     |> elem(1)
   end
 
@@ -19,7 +19,7 @@ defmodule Httpdigest do
   def create_response(username, password, path, auth) do
     ha1 = md5(username <> ":" <> auth["realm"] <> ":" <> password)
     ha2 = md5("GET:#{path}")
-    client_nonce =  cnonce
+    client_nonce =  cnonce()
     nc = "00000001"
     response = md5("#{ha1}:#{auth["nonce"]}:#{nc}:#{client_nonce}:#{auth["qop"]}:#{ha2}")
     result = Map.to_list(%{
@@ -43,7 +43,7 @@ defmodule Httpdigest do
     "Digest #{result}"
   end
 
-  defp cnonce do
+  defp cnonce() do
      :crypto.strong_rand_bytes(4)
      |> Base.encode16(case: :lower)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Httpdigest.Mixfile do
   use Mix.Project
 
-  def project do
+  def project() do
     [app: :httpdigest,
      version: "0.0.1",
      elixir: "~> 1.2",

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Httpdigest.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Httpdigest.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger,:httpoison]]
+    [applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:
@@ -26,7 +26,6 @@ defmodule Httpdigest.Mixfile do
   #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
   #
   # Type "mix help deps" for more examples and options
-  defp deps do
-    [{:httpoison, "~> 0.8.0"}]
+  defp deps() do
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,5 @@
 %{"certifi": {:hex, :certifi, "0.4.0"},
   "hackney": {:hex, :hackney, "1.6.0"},
-  "httpoison": {:hex, :httpoison, "0.8.3"},
   "idna": {:hex, :idna, "1.2.0"},
   "metrics": {:hex, :metrics, "1.0.1"},
   "mimerl": {:hex, :mimerl, "1.0.2"},


### PR DESCRIPTION
Couple minor fixes:

- drop HTTPoison as dependency (bye-bye dependency conflicts)
- allow to specify request method
- add parenthesis to get rid of Elixir v1.4 warnings