### PR TITLE
Fix bug: trim extra spaces around auth params

### DIFF
--- a/lib/httpdigest.ex
+++ b/lib/httpdigest.ex
@@ -10,7 +10,7 @@ defmodule Httpdigest do
     String.replace(auth, "Digest ", "")
     |> String.split(",")
     |> Enum.reduce(%{}, fn(string, acc) ->
-      parse_map = Regex.named_captures(~r/(?<key>.+)="(?<val>.+)"/, string)
+      parse_map = Regex.named_captures(~r/\s*(?<key>.+?)\s*=\s*"(?<val>.+)"/, string)
       item = %{parse_map["key"] => parse_map["val"]}
       Map.merge(acc, item)
     end)


### PR DESCRIPTION
In the current implementation `parse_map["key"]` may contain extra spaces around parameter names (e.g. `" nonce"`).