### PR TITLE
response is a List, not a Map

### DIFF
--- a/lib/httpdigest.ex
+++ b/lib/httpdigest.ex
@@ -1,7 +1,7 @@
 defmodule Httpdigest do
   def get_header(headers, key) do
     headers
-    |> Enum.filter(fn({k, _}) -> String.downcase(k) == String.downcase(key) end)
+    |> Enum.filter(fn {k, _} -> String.downcase(k) == String.downcase(key) end)
     |> hd()
     |> elem(1)
   end
@@ -9,7 +9,7 @@ defmodule Httpdigest do
   def parse_auth(auth) do
     String.replace(auth, "Digest ", "")
     |> String.split(",")
-    |> Enum.reduce(%{}, fn(string, acc) ->
+    |> Enum.reduce(%{}, fn string, acc ->
       parse_map = Regex.named_captures(~r/\s*(?<key>.+?)\s*=\s*"(?<val>.+)"/, string)
       item = %{parse_map["key"] => parse_map["val"]}
       Map.merge(acc, item)
@@ -19,38 +19,40 @@ defmodule Httpdigest do
   def create_response(username, password, method \\ "GET", path, auth) do
     ha1 = md5(username <> ":" <> auth["realm"] <> ":" <> password)
     ha2 = md5("#{method}:#{path}")
-    client_nonce =  cnonce()
+    client_nonce = cnonce()
     nc = "00000001"
     response = md5("#{ha1}:#{auth["nonce"]}:#{nc}:#{client_nonce}:#{auth["qop"]}:#{ha2}")
-    result = Map.to_list(%{
-      "username" => username,
-      "realm" => auth["realm"],
-      "nonce" => auth["nonce"],
-      "uri" => path,
-      "qop" => auth["qop"],
-      "nc" => nc,
-      "cnonce" => client_nonce,
-      "response" => response,
-    })
-    |> add_opaque(auth["opaque"])
-    |> Enum.reduce([], fn({key, val}, acc) ->
-      case key do
-        "nc" -> acc ++ ["#{key}=#{val}"]
-        _ -> acc ++ ["#{key}=\"#{val}\""]
-      end
-    end)
-    |> Enum.join(",")
+
+    result =
+      Map.to_list(%{
+        "username" => username,
+        "realm" => auth["realm"],
+        "nonce" => auth["nonce"],
+        "uri" => path,
+        "qop" => auth["qop"],
+        "nc" => nc,
+        "cnonce" => client_nonce,
+        "response" => response
+      })
+      |> add_opaque(auth["opaque"])
+      |> Enum.reduce([], fn {key, val}, acc ->
+        case key do
+          "nc" -> acc ++ ["#{key}=#{val}"]
+          _ -> acc ++ ["#{key}=\"#{val}\""]
+        end
+      end)
+      |> Enum.join(",")
 
     "Digest #{result}"
   end
 
   defp cnonce() do
-     :crypto.strong_rand_bytes(4)
-     |> Base.encode16(case: :lower)
+    :crypto.strong_rand_bytes(4)
+    |> Base.encode16(case: :lower)
   end
 
   def md5(data) do
-      Base.encode16(:erlang.md5(data), case: :lower)
+    Base.encode16(:erlang.md5(data), case: :lower)
   end
 
   def create_header(headers, username, password, method \\ "GET", path) do
@@ -61,5 +63,8 @@ defmodule Httpdigest do
   end
 
   defp add_opaque(response, opaque) when opaque in [nil, ""], do: response
-  defp add_opaque(response, opaque), do: Map.put(response, "opaque", opaque)
+
+  defp add_opaque(response, opaque) do
+    response ++ [{"opaque", opaque}]
+  end
 end


### PR DESCRIPTION
Hi,
When trying to authenticate against clock-pms, I got the following error:
```
** (EXIT from #PID<0.544.0>) shell process exited with reason: an exception was raised:
    ** (BadMapError) expected a map, got: [{"cnonce", "07f4c8e2"}, {"nc", "00000001"}, {"nonce", "MTUzMDI2OTExOTo1ZmYwODVlNzY0MTM5OWVmZWI3M2NiZmNkZTdmYzQ5YQ=="}, {"qop", "auth"}, {"realm", "API"}, {"response", "8b53684e979468eb56415bc0b3e35e0a"}, {"uri", "https://sky-eu1.clock-software.com/base_api/XXXXX/YYYYYY"}, {"username", "iZZZZZZ"}]
        (stdlib) :maps.put("opaque", "b816d4d26130bed8ccf5149e855000ad", [{"cnonce", "07f4c8e2"}, {"nc", "00000001"}, {"nonce", "MTUzMDI2OTExOTo1ZmYwODVlNzY0MTM5OWVmZWI3M2NiZmNkZTdmYzQ5YQ=="}, {"qop", "auth"}, {"realm", "API"}, {"response", "8b53684e979468eb56415bc0b3e35e0a"}, {"uri", "https://sky-eu1.clock-software.com/base_api/XXXXX/YYYYYY"}, {"username", "iZZZZZZ"}])
        (httpdigest) lib/httpdigest.ex:69: Httpdigest.add_opaque/2
        (httpdigest) lib/httpdigest.ex:37: Httpdigest.create_response/5
        (httpdigest) lib/httpdigest.ex:61: Httpdigest.create_header/5
        (pms_proxy) lib/pms_proxy/clock.ex:25: PmsProxy.Clock.handle_cast/2
        (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
        (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
        (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```

The response argument to add_opaque/2 is a List, not a Map.
After making this change I was able to authenticate.

I do have the Elixir Formatter active, that is the cause of the other changes.
